### PR TITLE
Implements yarn-to-mcp task

### DIFF
--- a/src/main/java/me/ramidzkh/yarnforge/YarnForgePlugin.java
+++ b/src/main/java/me/ramidzkh/yarnforge/YarnForgePlugin.java
@@ -59,6 +59,7 @@ public class YarnForgePlugin implements Plugin<Project> {
             };
 
             target.getTasks().register("userRemapYarn", UserRemapTask.class, configurationAction);
+            target.getTasks().register("UserRemapTaskY2M", UserRemapTaskY2M.class, configurationAction);
             target.getTasks().register("spongeRemapYarn", SpongeCommonRemapTask.class, configurationAction);
             // TODO: Make this the default
             //  This should be used in UserRemapTask's place

--- a/src/main/java/me/ramidzkh/yarnforge/YarnForgePlugin.java
+++ b/src/main/java/me/ramidzkh/yarnforge/YarnForgePlugin.java
@@ -59,7 +59,7 @@ public class YarnForgePlugin implements Plugin<Project> {
             };
 
             target.getTasks().register("userRemapYarn", UserRemapTask.class, configurationAction);
-            target.getTasks().register("UserRemapTaskY2M", UserRemapTaskY2M.class, configurationAction);
+            target.getTasks().register("userRemapYarn2MCP", UserRemapTaskY2M.class, configurationAction);
             target.getTasks().register("spongeRemapYarn", SpongeCommonRemapTask.class, configurationAction);
             // TODO: Make this the default
             //  This should be used in UserRemapTask's place

--- a/src/main/java/me/ramidzkh/yarnforge/task/BaseRemappingTask.java
+++ b/src/main/java/me/ramidzkh/yarnforge/task/BaseRemappingTask.java
@@ -88,9 +88,13 @@ public abstract class BaseRemappingTask extends DefaultTask {
         this.namesProvider = namesProvider;
     }
 
-    protected Mercury createRemapper() throws IOException {
+    protected Mercury createRemapper(boolean yarn2mcp) throws IOException {
         Mercury mercury = new Mercury();
         MappingSet mappings = createMcpToYarn();
+        
+        if (yarn2mcp) {
+            mappings = mappings.reverse();
+        }
 
         if (mixin) {
             mercury.getProcessors().add(MixinRemapper.create(mappings));
@@ -100,6 +104,10 @@ public abstract class BaseRemappingTask extends DefaultTask {
         mercury.getProcessors().add(MercuryRemapper.create(mappings, false));
         mercury.getProcessors().add(new YarnForgeRewriter(mappings));
         return mercury;
+    }
+
+    protected Mercury createRemapper() throws IOException {
+        return createRemapper(false);
     }
 
     private MappingSet createMcpToYarn() throws IOException {

--- a/src/main/java/me/ramidzkh/yarnforge/task/BaseRemappingTask.java
+++ b/src/main/java/me/ramidzkh/yarnforge/task/BaseRemappingTask.java
@@ -25,6 +25,7 @@ import net.fabricmc.mapping.tree.TinyMappingFactory;
 import net.fabricmc.mapping.tree.TinyTree;
 import net.fabricmc.stitch.commands.CommandMergeJar;
 import net.fabricmc.stitch.commands.CommandProposeFieldNames;
+import net.fabricmc.stitch.commands.tinyv2.TinyV2Writer;
 import net.minecraftforge.gradle.common.util.Artifact;
 import net.minecraftforge.gradle.common.util.MinecraftRepo;
 import org.cadixdev.bombe.analysis.CachingInheritanceProvider;
@@ -161,6 +162,7 @@ public abstract class BaseRemappingTask extends DefaultTask {
         debug("obfToMcp", obfToMcp);
         debug("mcpToYarn", mcpToYarn);
 
+    	TinyV2Writer.write(MappingBridge.saveTiny(pair.left, obfToMcp), getProject().file("remapped/mcp.tiny").toPath());
         return mcpToYarn;
     }
 

--- a/src/main/java/me/ramidzkh/yarnforge/task/UserRemapTaskY2M.java
+++ b/src/main/java/me/ramidzkh/yarnforge/task/UserRemapTaskY2M.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Ramid Khan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ramidzkh.yarnforge.task;
+
+import org.cadixdev.mercury.Mercury;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+
+public class UserRemapTaskY2M extends BaseRemappingTask {
+    @TaskAction
+    public void doTask() throws Exception {
+        Project project = getProject();
+
+        try {
+            Mercury mercury = createRemapper(true);
+
+            for (File file : getAllDependencies()) {
+            	String fileName = file.getName().toLowerCase();
+            	// Do not add the MCP-mapped vanilla jar
+            	if (!fileName.startsWith("forge-") && !fileName.endsWith("-recomp.jar")) {
+            		mercury.getClassPath().add(file.toPath());
+            	}
+            }
+
+            // Add the Yarn-mapped vanilla jar, copied from Fabric-loom
+            File libsDir = project.file("libs");
+            for (File file: libsDir.listFiles()) {
+            	mercury.getClassPath().add(file.toPath());
+            }
+
+            project.getLogger().lifecycle(":remapping");
+            mercury.rewrite(project.file("src_yarn/main/java").toPath(), project.file("remapped").toPath());
+        } finally {
+            System.gc();
+        }
+    }
+}


### PR DESCRIPTION
Adds a new task `UserRemapTaskY2M` which allows Yarn to MCP mapping.

To use this service, first, the user need to setup the target project and yarnforge-plugin just like when using `UserRemapTask`. Then, a copy of yarn-mapped vanilla jar (In my case, `minecraft-1.16.2-mapped-net.fabricmc.yarn-1.16.2+build.43-v2.jar`) need to be copied to the `libs` folder under the root of target project. Create the libs folder if it does not exist. Finally, run `gradlew UserRemapTaskY2M --mappings net.fabricmc:yarn:1.16.2+build.47 --mc-version 1.16.2 --no-daemon`, the sources in `src_yarn/main/java` will be remapped to MCP and placed into `remapped` dir.

Is there a way to avoid manually copying the yarn-mapped vanilla jar by integrating Fabric Loom? I'm not familiar with gradle, so may be I need help on this.